### PR TITLE
Add placeholder chatbot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ Then I answered:
 5. I would prefer it remembers previous interactions and keep a conversation history, but separate from my personal conversation history. If needed I could start him a new OpenAI account. Let's have it always on, and I can put a physical cut off switch in the mic line.
 6. The bot will be used only by my father. Plan to store the OpenAI API key on the Pi.
 7. I do want the chatbot code to be version-controlled in my Git repository. I am comfortable troubleshooting audio configuration on the pi.
+
+## Running the demo
+
+1. Ensure you have Python 3 installed.
+2. Run `python main.py` and type your message when prompted.
+3. The placeholder functions currently echo a canned response. Replace them
+   with real microphone input, OpenAI API calls, and text-to-speech output as
+you add dependencies.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,62 @@
+# main.py
+"""Simple CLI interface for a Raspberry Pi chatbot.
+
+This file defines placeholder functions for capturing audio, sending text to
+OpenAI's API, and generating speech. The current implementation uses standard
+input/output so you can test the conversation loop without additional
+libraries. Audio input/output libraries can be added later.
+"""
+
+from typing import Optional
+
+
+def capture_audio() -> str:
+    """Placeholder for microphone input.
+
+    Returns text typed by the user for now.
+    """
+    return input("You: ")
+
+
+def send_to_openai(prompt: str) -> str:
+    """Placeholder for sending a prompt to the OpenAI API.
+
+    Args:
+        prompt: The user's question or statement.
+
+    Returns a mock response string. Replace the body of this function with
+    actual API calls once the `openai` package is installed and configured.
+    """
+    # TODO: integrate openai.Completion or Chat API
+    print("[DEBUG] Sending to OpenAI:", prompt)
+    return "This is a placeholder response from OpenAI."
+
+
+def speak_text(text: str) -> None:
+    """Placeholder for text-to-speech output.
+
+    Args:
+        text: The response text to vocalize.
+
+    Currently prints the text to the console. Replace with a TTS library
+    (e.g., pyttsx3 or gTTS) to output audio.
+    """
+    print("Bot:", text)
+
+
+def main() -> None:
+    """Run a single-turn conversation loop."""
+    print("Press Ctrl+C to exit.")
+    try:
+        while True:
+            user_text = capture_audio()
+            if not user_text:
+                continue
+            response = send_to_openai(user_text)
+            speak_text(response)
+    except KeyboardInterrupt:
+        print("\nExiting.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a minimal `main.py` with stub functions for capturing audio, sending text to OpenAI, and speaking a response
- document how to run the placeholder script in README

## Testing
- `python main.py <<'EOF'
Hello
EOF` *(fails: EOF when reading a line after first interaction)*

------
https://chatgpt.com/codex/tasks/task_e_684309f5b888832480f170320930e184