### PR TITLE
Refresh chatbot runtime and add 2026 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,55 @@
 # Trial_Run
 
 ## Project Overview
-This repository contains the initial work for a Raspberry Pi–based voice chatbot. The goal is to embed a Pi 4 inside a plastic skull with a microphone and speaker so it can converse using OpenAI and sound like Bob the skull from *The Dresden Files*. Responses will be generated using the OpenAI API and read aloud via a text-to-speech engine.
+This repository contains a Raspberry Pi–based voice chatbot prototype. The long-term goal is to run it inside a prop skull with a microphone, speaker, wake word activation, and OpenAI-backed conversation.
 
 ## Getting Started
-1. **Install Python 3** (if not already present)
-   ```bash
-   sudo apt-get update
-   sudo apt-get install python3 python3-pip
-   ```
-2. **Install required libraries**
+1. Install Python and dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-   The `requirements.txt` file lists the core packages (`speechrecognition`,
-   `pyttsx3` and `openai`) and notes the optional `RPi.GPIO` dependency for
-   Raspberry Pi hardware. You can substitute another text-to-speech engine if
-   preferred. If you plan to run with ``--tts-engine gtts`` you will also need
-   the ``gtts`` and ``playsound`` packages installed.
-3. **Configure your OpenAI API key**
+2. Set your API key:
    ```bash
    export OPENAI_API_KEY=<your-api-key>
    ```
-   Add this line to your shell profile (e.g., `.bashrc`) so the application can access the key at runtime.
+3. Run:
+   ```bash
+   python3 main.py --use-typing
+   ```
 
-## Roadmap / Next Steps
-- Maintain conversation history for context
-- A simple GPIO wrapper in `hardware.py` handles microphone and speaker control
+## Current Features
+- Continuous conversation loop
+- Optional wake word (`--wake-word`)
+- Typed input fallback (`--use-typing`)
+- TTS via `pyttsx3` or `gtts` (`--tts-engine`)
+- Optional history persistence (`--history-file`)
+- Optional GPIO mic/speaker control (`--mic-pin`, `--speaker-pin`)
 
-### New Features
-- **Continuous listening mode**: the chatbot can now listen for speech input
-  in a loop. Run with microphone support (requires the ``speechrecognition``
-  package) or use ``--use-typing`` to fall back to keyboard input.
-- **Optional wake word**: supply ``--wake-word <word>`` to require a wake word
-  before the assistant records the next prompt.
-- **Text-to-speech options**: choose ``--tts-engine pyttsx3`` or ``gtts`` and
-  pass ``--no-tts`` to disable audio output entirely. When selecting
-  ``gtts`` you must have the ``gtts`` and ``playsound`` packages installed.
+## Refreshed Roadmap (2026)
 
-## Usage
+### Phase 1: Stabilize the Core (next)
+- Add structured configuration (env + config file + CLI precedence)
+- Add robust logging (info/debug/error) and better runtime diagnostics
+- Add history limits/summarization to prevent token bloat
+- Expand tests around persistence and error paths
 
-Run the chatbot with the microphone and offline text-to-speech (``pyttsx3``) like so:
-```bash
-python3 main.py
-```
+### Phase 2: Modernize OpenAI Integration
+- Add a dedicated OpenAI client module
+- Support model configuration by CLI/env
+- Add retry/backoff for transient API failures
+- Add optional streaming responses for lower perceived latency
 
-If you prefer to type your prompts, add ``--use-typing``. To require a wake word
-before each prompt, supply ``--wake-word <word>``. You can switch to Google TTS
-with ``--tts-engine gtts`` or disable audio entirely using ``--no-tts``.
-Using the ``gtts`` engine requires the ``gtts`` and ``playsound`` packages.
+### Phase 3: Hardware Reliability
+- Improve GPIO abstraction to support non-RPi dev environments cleanly
+- Add push-to-talk mode and audio device selection
+- Add graceful recovery for microphone/speaker initialization failures
 
-The script sends each prompt to OpenAI using the ``OPENAI_API_KEY`` environment
-variable. Responses are spoken aloud with the chosen TTS engine and printed to
-the console.
+### Phase 4: Product Experience
+- Persona prompt management (e.g., “Bob voice profile” presets)
+- Session commands (clear history, save snapshot, status)
+- Packaging for Raspberry Pi deployment (systemd service + install script)
 
 ## Running Tests
-
-The unit tests use [pytest](https://pytest.org/). Install the dependency and run
+```bash
+pytest -q
 ```
-pip install pytest
-pytest
-```
-from the repository root.

--- a/hardware.py
+++ b/hardware.py
@@ -32,3 +32,10 @@ class HardwareController:
 
     def cleanup(self) -> None:
         GPIO.cleanup()
+
+    # Allow use as a context manager for automatic cleanup
+    def __enter__(self) -> "HardwareController":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.cleanup()

--- a/main.py
+++ b/main.py
@@ -1,69 +1,69 @@
-# main.py
-"""CLI interface for a Raspberry Pi chatbot with optional voice support.
+"""CLI interface for a Raspberry Pi chatbot with optional voice support."""
 
-The initial version only accepted typed input. This update introduces
-continuous listening using the :mod:`speech_recognition` library and an
-optional wake word. Audio input/output can be replaced with more advanced
-libraries later.
-"""
+from __future__ import annotations
 
-from typing import Optional
 import argparse
+import importlib
+import json
 import os
 import tempfile
+from typing import Any, Optional
 
-try:
-    import pyttsx3
-except ImportError:  # pragma: no cover - pyttsx3 may not be installed
-    pyttsx3 = None  # type: ignore
+from hardware import HardwareController
 
-try:
-    from gtts import gTTS
-    from playsound import playsound
-except ImportError:  # pragma: no cover - gTTS/playsound may not be installed
-    gTTS = None  # type: ignore
-    playsound = None  # type: ignore
 
-try:
-    import openai
-    from openai.error import OpenAIError
-except ImportError:  # pragma: no cover - openai may not be installed
-    openai = None  # type: ignore
-    OpenAIError = Exception  # type: ignore
+def optional_import(module_name: str) -> Any:
+    """Import ``module_name`` and return ``None`` if unavailable."""
+    try:
+        return importlib.import_module(module_name)
+    except Exception:  # pragma: no cover - optional dependency
+        return None
 
-try:
-    import speech_recognition as sr
-except ImportError:  # pragma: no cover - speech_recognition may not be installed
-    sr = None
 
-# Configure OpenAI API if available
-if openai is not None:
+pyttsx3 = optional_import("pyttsx3")
+gtts_module = optional_import("gtts")
+playsound_module = optional_import("playsound")
+openai = optional_import("openai")
+sr = optional_import("speech_recognition")
+
+if openai is not None and hasattr(openai, "api_key"):
     openai.api_key = os.getenv("OPENAI_API_KEY")
 
-# Conversation history for chat context
-history = [
-    {
-        "role": "system",
-        "content": "You are a helpful assistant."
-    }
-]
+history = [{"role": "system", "content": "You are a helpful assistant."}]
 
 
-def capture_audio(recognizer: Optional["sr.Recognizer"] = None, *, typed_input: bool = False) -> str:
-    """Capture a single utterance from the user.
+def load_history(path: str) -> None:
+    if not path or not os.path.exists(path):
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            history.extend(item for item in data if isinstance(item, dict))
+    except Exception as exc:  # pragma: no cover
+        print(f"[WARN] Could not load history file: {exc}")
 
-    If ``typed_input`` is True or no microphone support is available, this
-    falls back to ``input()``. Otherwise it listens on the microphone using
-    ``speech_recognition``.
-    """
+
+def save_history(path: str) -> None:
+    if not path:
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(history[1:], f, indent=2)
+    except Exception as exc:  # pragma: no cover
+        print(f"[WARN] Could not save history file: {exc}")
+
+
+def capture_audio(recognizer=None, *, typed_input: bool = False, hardware_ctrl=None) -> str:
     if typed_input or recognizer is None or sr is None:
         return input("You: ")
 
-    with sr.Microphone() as source:
-        print("Listening...")
-        audio = recognizer.listen(source)
-
+    if hardware_ctrl is not None:
+        hardware_ctrl.mic_on()
     try:
+        with sr.Microphone() as source:
+            print("Listening...")
+            audio = recognizer.listen(source)
         text = recognizer.recognize_google(audio)
         print(f"You said: {text}")
         return text
@@ -73,133 +73,125 @@ def capture_audio(recognizer: Optional["sr.Recognizer"] = None, *, typed_input: 
     except sr.RequestError as exc:
         print(f"[DEBUG] Speech recognition error: {exc}")
         return ""
+    finally:
+        if hardware_ctrl is not None:
+            hardware_ctrl.mic_off()
 
 
-def listen_for_wake_word(recognizer: Optional["sr.Recognizer"], wake_word: str, *, typed_input: bool = False) -> None:
-    """Block until the wake word is detected."""
+def listen_for_wake_word(recognizer, wake_word: str, *, typed_input: bool = False, hardware_ctrl=None) -> None:
     if not wake_word:
         return
-    prompt = f"Say or type '{wake_word}' to activate."
-    print(prompt)
+    print(f"Say or type '{wake_word}' to activate.")
     while True:
-        text = capture_audio(recognizer, typed_input=typed_input)
+        text = capture_audio(recognizer, typed_input=typed_input, hardware_ctrl=hardware_ctrl)
         if wake_word.lower() in text.lower():
             return
 
 
-def send_to_openai(prompt: str) -> str:
-    """Send ``prompt`` to the OpenAI Chat API using ``history`` for context."""
+def _send_with_legacy_openai(prompt: str) -> str:
+    history.append({"role": "user", "content": prompt})
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=history)
+    text = response.choices[0].message["content"].strip()
+    history.append({"role": "assistant", "content": text})
+    return text
 
+
+def send_to_openai(prompt: str) -> str:
     if openai is None:
         print("[ERROR] The openai package is not installed.")
         return "OpenAI support is unavailable."
 
-    if not openai.api_key:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
         print("[ERROR] OPENAI_API_KEY environment variable not set.")
         return "OpenAI API key missing."
 
-    history.append({"role": "user", "content": prompt})
     try:
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=history,
-        )
-        text = response.choices[0].message["content"].strip()
-        history.append({"role": "assistant", "content": text})
-        return text
-    except OpenAIError as exc:
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            history.append({"role": "user", "content": prompt})
+            response = client.chat.completions.create(model="gpt-4o-mini", messages=history)
+            text = (response.choices[0].message.content or "").strip()
+            history.append({"role": "assistant", "content": text})
+            return text
+        return _send_with_legacy_openai(prompt)
+    except Exception as exc:  # pragma: no cover
         print(f"[ERROR] OpenAI API error: {exc}")
         return "Sorry, I couldn't reach OpenAI."
-    except Exception as exc:  # pragma: no cover - unexpected errors
-        print(f"[ERROR] Unexpected error: {exc}")
-        return "Sorry, something went wrong."
 
 
-def speak_text(text: str, *, tts_enabled: bool = True, engine: str = "pyttsx3") -> None:
-    """Convert ``text`` to speech if possible and print it to the console.
-
-    Parameters
-    ----------
-    text:
-        The response text to vocalize.
-    tts_enabled:
-        When ``False`` no audio will be played.
-    engine:
-        ``"pyttsx3"`` for offline speech or ``"gtts"`` for Google TTS.
-    """
+def speak_text(text: str, *, tts_enabled: bool = True, engine: str = "pyttsx3", hardware_ctrl=None) -> None:
     print("Bot:", text)
     if not tts_enabled:
         return
 
-    if engine == "pyttsx3":
-        if pyttsx3 is None:
-            print("[WARN] pyttsx3 not installed")
-            return
-        try:
+    if hardware_ctrl is not None:
+        hardware_ctrl.speaker_on()
+
+    try:
+        if engine == "pyttsx3":
+            if pyttsx3 is None:
+                print("[WARN] pyttsx3 not installed")
+                return
             tts_engine = pyttsx3.init()
             tts_engine.say(text)
             tts_engine.runAndWait()
-        except Exception as exc:  # pragma: no cover - runtime TTS errors
-            print(f"[ERROR] pyttsx3 error: {exc}")
-    else:  # gtts
-        if gTTS is None or playsound is None:
-            print("[WARN] gTTS or playsound not installed")
-            return
-        try:
+        else:
+            if gtts_module is None or playsound_module is None:
+                print("[WARN] gTTS or playsound not installed")
+                return
             with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as fp:
-                gTTS(text=text).save(fp.name)
-            playsound(fp.name)
-        except Exception as exc:  # pragma: no cover - runtime TTS errors
-            print(f"[ERROR] gTTS error: {exc}")
-        finally:
-            try:
-                os.remove(fp.name)
-            except OSError:
-                pass
+                gtts_module.gTTS(text=text).save(fp.name)
+            playsound_module.playsound(fp.name)
+            os.remove(fp.name)
+    except Exception as exc:  # pragma: no cover
+        print(f"[ERROR] TTS error: {exc}")
+    finally:
+        if hardware_ctrl is not None:
+            hardware_ctrl.speaker_off()
 
 
 def main() -> None:
-    """Run the conversation loop."""
     parser = argparse.ArgumentParser(description="Simple voice chatbot demo")
-    parser.add_argument(
-        "--wake-word",
-        help="Optional wake word required before capturing speech",
-    )
-    parser.add_argument(
-        "--use-typing",
-        action="store_true",
-        help="Use typed input instead of microphone audio",
-    )
-    parser.add_argument(
-        "--tts-engine",
-        choices=["pyttsx3", "gtts"],
-        default="pyttsx3",
-        help="Text-to-speech engine to use",
-    )
-    parser.add_argument(
-        "--no-tts",
-        action="store_true",
-        help="Disable audio playback of responses",
-    )
+    parser.add_argument("--wake-word")
+    parser.add_argument("--use-typing", action="store_true")
+    parser.add_argument("--tts-engine", choices=["pyttsx3", "gtts"], default="pyttsx3")
+    parser.add_argument("--no-tts", action="store_true")
+    parser.add_argument("--history-file")
+    parser.add_argument("--mic-pin", type=int)
+    parser.add_argument("--speaker-pin", type=int)
     args = parser.parse_args()
 
     recognizer = sr.Recognizer() if sr and not args.use_typing else None
-
     tts_enabled = not args.no_tts
+
+    hardware_ctrl = None
+    if args.mic_pin is not None and args.speaker_pin is not None:
+        try:
+            hardware_ctrl = HardwareController(args.mic_pin, args.speaker_pin)
+        except Exception as exc:  # pragma: no cover
+            print(f"[WARN] Could not initialize hardware controller: {exc}")
+
+    if args.history_file:
+        load_history(args.history_file)
 
     print("Press Ctrl+C to exit.")
     try:
         while True:
             if args.wake_word:
-                listen_for_wake_word(recognizer, args.wake_word, typed_input=args.use_typing)
-
-            user_text = capture_audio(recognizer, typed_input=args.use_typing)
+                listen_for_wake_word(recognizer, args.wake_word, typed_input=args.use_typing, hardware_ctrl=hardware_ctrl)
+            user_text = capture_audio(recognizer, typed_input=args.use_typing, hardware_ctrl=hardware_ctrl)
             if not user_text:
                 continue
             response = send_to_openai(user_text)
-            speak_text(response, tts_enabled=tts_enabled, engine=args.tts_engine)
+            speak_text(response, tts_enabled=tts_enabled, engine=args.tts_engine, hardware_ctrl=hardware_ctrl)
+            if args.history_file:
+                save_history(args.history_file)
     except KeyboardInterrupt:
         print("\nExiting.")
+    finally:
+        if hardware_ctrl is not None:
+            hardware_ctrl.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -29,3 +29,19 @@ def test_hardware_controller_calls_gpio(monkeypatch):
     mock_gpio.output.assert_any_call(3, 0)
     mock_gpio.output.assert_any_call(4, 0)
     mock_gpio.cleanup.assert_called_once()
+
+
+def test_hardware_controller_context_manager(monkeypatch):
+    mock_gpio = mock.MagicMock()
+    mock_gpio.BCM = "BCM"
+    mock_gpio.OUT = "OUT"
+    mock_gpio.HIGH = 1
+    mock_gpio.LOW = 0
+    monkeypatch.setattr(hardware, "GPIO", mock_gpio)
+
+    with hardware.HardwareController(1, 2) as ctrl:
+        ctrl.mic_on()
+        ctrl.speaker_on()
+
+    mock_gpio.setmode.assert_called_with("BCM")
+    mock_gpio.cleanup.assert_called()

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -6,11 +6,12 @@ from unittest import mock
 import main
 
 
-def test_cli_options(monkeypatch):
+def test_cli_options(monkeypatch, tmp_path):
     events = {}
 
-    def fake_capture_audio(recognizer, *, typed_input=False):
+    def fake_capture_audio(recognizer, *, typed_input=False, hardware_ctrl=None):
         events['typed_input'] = typed_input
+        events['hw_capture'] = hardware_ctrl is not None
         if 'called' in events:
             raise KeyboardInterrupt
         events['called'] = True
@@ -20,12 +21,14 @@ def test_cli_options(monkeypatch):
         events['prompt'] = prompt
         return 'hi'
 
-    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3'):
+    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3', hardware_ctrl=None):
         events['tts_enabled'] = tts_enabled
         events['engine'] = engine
+        events['hw_speak'] = hardware_ctrl is not None
 
-    def fake_listen_for_wake_word(recognizer, wake_word, *, typed_input=False):
+    def fake_listen_for_wake_word(recognizer, wake_word, *, typed_input=False, hardware_ctrl=None):
         events['wake_word'] = wake_word
+        events['hw_wake'] = hardware_ctrl is not None
 
     monkeypatch.setattr(main, 'capture_audio', fake_capture_audio)
     monkeypatch.setattr(main, 'send_to_openai', fake_send_to_openai)
@@ -33,9 +36,14 @@ def test_cli_options(monkeypatch):
     monkeypatch.setattr(main, 'listen_for_wake_word', fake_listen_for_wake_word)
     monkeypatch.setattr(main, 'sr', None)
 
-    argv = ['prog', '--use-typing', '--no-tts', '--tts-engine', 'gtts', '--wake-word', 'yo']
+    hist_file = tmp_path / 'hist.json'
+    argv = [
+        'prog', '--use-typing', '--no-tts', '--tts-engine', 'gtts', '--wake-word', 'yo',
+        '--mic-pin', '1', '--speaker-pin', '2', '--history-file', str(hist_file)
+    ]
     monkeypatch.setattr(sys, 'argv', argv)
 
+    monkeypatch.setattr(main, 'HardwareController', mock.MagicMock())
     main.main()
 
     assert events['typed_input'] is True
@@ -43,3 +51,7 @@ def test_cli_options(monkeypatch):
     assert events['engine'] == 'gtts'
     assert events['wake_word'] == 'yo'
     assert events['prompt'] == 'hello'
+    assert events['hw_capture'] is True
+    assert events['hw_speak'] is True
+    assert events['hw_wake'] is True
+    assert hist_file.exists()


### PR DESCRIPTION
### Motivation
- The project had fragile import-time dependency handling and needed the runtime to be more robust for development and Pi deployment. 
- Conversation persistence and hardware control behavior required clearer, safer lifecycles to avoid leaving GPIO/TTS resources in an inconsistent state. 
- The repository needed an updated roadmap and guidance to resume active development in 2026. 

### Description
- Refactored `main.py` to centralize optional dependency loading via `optional_import()` (uses `importlib`) so missing packages are non-fatal at runtime. 
- Modernized OpenAI integration to prefer the new `openai.OpenAI` client with a legacy `ChatCompletion` fallback and preserved history updates in both paths. 
- Added and wired `load_history()` and `save_history()` helpers and new CLI support for `--history-file`, and limited history is persisted as JSON. 
- Improved hardware and TTS flow by passing a `HardwareController` into `capture_audio()`, `listen_for_wake_word()`, and `speak_text()`, added context-manager support in `hardware.py`, and ensured mic/speaker toggles and cleanup are invoked reliably via `finally` blocks. 

### Testing
- Ran the unit test suite with `pytest -q`, which completed successfully with `3 passed, 1 warning`. 
- Updated tests include `tests/test_main_cli.py` and `tests/test_hardware.py`, and they passed under the updated runtime changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_684b9e150620832484767e32ea8abc06)