### PR TITLE
Add ElevenLabs TTS engine

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,10 +6,10 @@ import argparse
 import importlib
 import json
 import os
-import tempfile
 from typing import Any, Optional
 
 from hardware import HardwareController
+import tts as tts_module
 
 
 def optional_import(module_name: str) -> Any:
@@ -20,9 +20,6 @@ def optional_import(module_name: str) -> Any:
         return None
 
 
-pyttsx3 = optional_import("pyttsx3")
-gtts_module = optional_import("gtts")
-playsound_module = optional_import("playsound")
 openai = optional_import("openai")
 sr = optional_import("speech_recognition")
 
@@ -125,40 +122,30 @@ def send_to_openai(prompt: str) -> str:
         return "Sorry, I couldn't reach OpenAI."
 
 
-def speak_text(text: str, *, tts_enabled: bool = True, engine: str = "pyttsx3", hardware_ctrl=None) -> None:
-    print("Bot:", text)
-
-    if hardware_ctrl is not None:
-        hardware_ctrl.speaker_on()
-
-    try:
-        if engine == "pyttsx3":
-            if pyttsx3 is None:
-                print("[WARN] pyttsx3 not installed")
-                return
-            tts_engine = pyttsx3.init()
-            tts_engine.say(text)
-            tts_engine.runAndWait()
-        else:
-            if gtts_module is None or playsound_module is None:
-                print("[WARN] gTTS or playsound not installed")
-                return
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as fp:
-                gtts_module.gTTS(text=text).save(fp.name)
-            playsound_module.playsound(fp.name)
-            os.remove(fp.name)
-    except Exception as exc:  # pragma: no cover
-        print(f"[ERROR] TTS error: {exc}")
-    finally:
-        if hardware_ctrl is not None:
-            hardware_ctrl.speaker_off()
+def speak_text(
+    text: str,
+    *,
+    tts_enabled: bool = True,
+    engine: str = "pyttsx3",
+    voice_id: str = "",
+    hardware_ctrl=None,
+) -> None:
+    if not tts_enabled:
+        print("Bot:", text)
+        return
+    tts_module.speak(text, engine=engine, voice_id=voice_id, hardware_ctrl=hardware_ctrl)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Simple voice chatbot demo")
     parser.add_argument("--wake-word")
     parser.add_argument("--use-typing", action="store_true")
-    parser.add_argument("--tts-engine", choices=["pyttsx3", "gtts"], default="pyttsx3")
+    parser.add_argument(
+        "--tts-engine",
+        choices=["pyttsx3", "gtts", "elevenlabs"],
+        default="pyttsx3",
+    )
+    parser.add_argument("--voice-id", default="", help="ElevenLabs voice ID")
     parser.add_argument("--no-tts", action="store_true")
     parser.add_argument("--history-file")
     parser.add_argument("--mic-pin", type=int)
@@ -187,7 +174,13 @@ def main() -> None:
             if not user_text:
                 continue
             response = send_to_openai(user_text)
-            speak_text(response, tts_enabled=tts_enabled, engine=args.tts_engine, hardware_ctrl=hardware_ctrl)
+            speak_text(
+                response,
+                tts_enabled=tts_enabled,
+                engine=args.tts_engine,
+                voice_id=args.voice_id,
+                hardware_ctrl=hardware_ctrl,
+            )
             if args.history_file:
                 save_history(args.history_file)
     except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 speechrecognition
 pyttsx3
 openai
+elevenlabs
 # Optional for Raspberry Pi hardware control
 # Uncomment the following line if running on a Pi
 # RPi.GPIO
+# Optional audio playback (pygame preferred on Pi, playsound for desktop)
+# pygame
 # Optional for Google TTS support
 # gtts
 # playsound

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -21,7 +21,7 @@ def test_cli_options(monkeypatch, tmp_path):
         events['prompt'] = prompt
         return 'hi'
 
-    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3', hardware_ctrl=None):
+    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3', voice_id='', hardware_ctrl=None):
         events['tts_enabled'] = tts_enabled
         events['engine'] = engine
         events['hw_speak'] = hardware_ctrl is not None

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,0 +1,110 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest import mock
+import tts
+
+
+def test_speak_no_tts_skips_engine(capsys):
+    """speak_text with tts_enabled=False should just print, not call any engine."""
+    with mock.patch.object(tts, "_speak_pyttsx3") as mock_p:
+        # Call the main module speak_text wrapper
+        import main
+        main.speak_text("hello", tts_enabled=False)
+        mock_p.assert_not_called()
+    out = capsys.readouterr().out
+    assert "hello" in out
+
+
+def test_speak_routes_to_pyttsx3(monkeypatch):
+    called = {}
+    monkeypatch.setattr(tts, "_speak_pyttsx3", lambda text: called.update({"text": text}))
+    tts.speak("hi", engine="pyttsx3")
+    assert called["text"] == "hi"
+
+
+def test_speak_routes_to_gtts(monkeypatch):
+    called = {}
+    monkeypatch.setattr(tts, "_speak_gtts", lambda text: called.update({"text": text}))
+    tts.speak("hello", engine="gtts")
+    assert called["text"] == "hello"
+
+
+def test_speak_routes_to_elevenlabs(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        tts, "_speak_elevenlabs", lambda text, voice_id="": called.update({"text": text, "vid": voice_id})
+    )
+    tts.speak("test", engine="elevenlabs", voice_id="abc123")
+    assert called["text"] == "test"
+    assert called["vid"] == "abc123"
+
+
+def test_elevenlabs_missing_voice_id(capsys):
+    tts._speak_elevenlabs("hi", voice_id="")
+    assert "voice-id" in capsys.readouterr().out
+
+
+def test_elevenlabs_missing_api_key(monkeypatch, capsys):
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    tts._speak_elevenlabs("hi", voice_id="some-id")
+    assert "ELEVENLABS_API_KEY" in capsys.readouterr().out
+
+
+def test_elevenlabs_missing_package(monkeypatch, capsys):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "fake-key")
+    monkeypatch.setattr(tts, "_optional", lambda name: None)
+    tts._speak_elevenlabs("hi", voice_id="some-id")
+    assert "elevenlabs" in capsys.readouterr().out.lower()
+
+
+def test_elevenlabs_calls_api(monkeypatch, tmp_path):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "fake-key")
+
+    fake_audio = [b"chunk1", b"chunk2"]
+    mock_client = mock.MagicMock()
+    mock_client.text_to_speech.convert.return_value = iter(fake_audio)
+
+    mock_el = mock.MagicMock()
+    mock_el.ElevenLabs.return_value = mock_client
+    monkeypatch.setattr(tts, "_optional", lambda name: mock_el if name == "elevenlabs" else None)
+
+    played = {}
+
+    def fake_play(path):
+        played["path"] = path
+        # verify file exists with expected content
+        with open(path, "rb") as f:
+            played["bytes"] = f.read()
+
+    monkeypatch.setattr(tts, "_play_audio_file", fake_play)
+
+    tts._speak_elevenlabs("hello Bob", voice_id="vid-123")
+
+    mock_client.text_to_speech.convert.assert_called_once_with(
+        voice_id="vid-123",
+        text="hello Bob",
+        model_id="eleven_turbo_v2_5",
+        output_format="mp3_44100_128",
+    )
+    assert played["bytes"] == b"chunk1chunk2"
+
+
+def test_speak_hardware_ctrl_called(monkeypatch):
+    monkeypatch.setattr(tts, "_speak_pyttsx3", lambda text: None)
+    hw = mock.MagicMock()
+    tts.speak("test", engine="pyttsx3", hardware_ctrl=hw)
+    hw.speaker_on.assert_called_once()
+    hw.speaker_off.assert_called_once()
+
+
+def test_speak_hardware_ctrl_off_on_error(monkeypatch):
+    def boom(text):
+        raise RuntimeError("tts exploded")
+
+    monkeypatch.setattr(tts, "_speak_pyttsx3", boom)
+    hw = mock.MagicMock()
+    tts.speak("test", engine="pyttsx3", hardware_ctrl=hw)
+    hw.speaker_on.assert_called_once()
+    hw.speaker_off.assert_called_once()

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,118 @@
+"""Text-to-speech engine abstraction."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import tempfile
+from typing import Any
+
+
+def _optional(name: str) -> Any:
+    try:
+        return importlib.import_module(name)
+    except Exception:
+        return None
+
+
+def speak(
+    text: str,
+    *,
+    engine: str = "pyttsx3",
+    voice_id: str = "",
+    hardware_ctrl=None,
+) -> None:
+    print("Bot:", text)
+
+    if hardware_ctrl is not None:
+        hardware_ctrl.speaker_on()
+    try:
+        if engine == "elevenlabs":
+            _speak_elevenlabs(text, voice_id=voice_id)
+        elif engine == "gtts":
+            _speak_gtts(text)
+        else:
+            _speak_pyttsx3(text)
+    except Exception as exc:
+        print(f"[ERROR] TTS error: {exc}")
+    finally:
+        if hardware_ctrl is not None:
+            hardware_ctrl.speaker_off()
+
+
+def _speak_pyttsx3(text: str) -> None:
+    pyttsx3 = _optional("pyttsx3")
+    if pyttsx3 is None:
+        print("[WARN] pyttsx3 not installed")
+        return
+    eng = pyttsx3.init()
+    eng.say(text)
+    eng.runAndWait()
+
+
+def _speak_gtts(text: str) -> None:
+    gtts_module = _optional("gtts")
+    playsound_module = _optional("playsound")
+    if gtts_module is None or playsound_module is None:
+        print("[WARN] gTTS or playsound not installed")
+        return
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as fp:
+        gtts_module.gTTS(text=text).save(fp.name)
+        fname = fp.name
+    playsound_module.playsound(fname)
+    os.remove(fname)
+
+
+def _speak_elevenlabs(text: str, *, voice_id: str = "") -> None:
+    if not voice_id:
+        print("[ERROR] --voice-id is required for ElevenLabs TTS")
+        return
+
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    if not api_key:
+        print("[ERROR] ELEVENLABS_API_KEY environment variable not set")
+        return
+
+    elevenlabs = _optional("elevenlabs")
+    if elevenlabs is None:
+        print("[WARN] elevenlabs package not installed — run: pip install elevenlabs")
+        return
+
+    client = elevenlabs.ElevenLabs(api_key=api_key)
+    audio_chunks = client.text_to_speech.convert(
+        voice_id=voice_id,
+        text=text,
+        # eleven_turbo_v2_5 gives the lowest latency — good for Pi real-time use
+        model_id="eleven_turbo_v2_5",
+        output_format="mp3_44100_128",
+    )
+    audio_bytes = b"".join(audio_chunks)
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as fp:
+        fp.write(audio_bytes)
+        fname = fp.name
+
+    try:
+        _play_audio_file(fname)
+    finally:
+        os.remove(fname)
+
+
+def _play_audio_file(path: str) -> None:
+    """Play an audio file using pygame (preferred on Pi) or playsound."""
+    pygame = _optional("pygame")
+    if pygame is not None:
+        pygame.mixer.init()
+        pygame.mixer.music.load(path)
+        pygame.mixer.music.play()
+        while pygame.mixer.music.get_busy():
+            pygame.time.Clock().tick(10)
+        pygame.mixer.quit()
+        return
+
+    playsound = _optional("playsound")
+    if playsound is not None:
+        playsound.playsound(path)
+        return
+
+    print("[WARN] No audio playback library available — install pygame or playsound")


### PR DESCRIPTION
## Summary
- Extracts all TTS logic into a new `tts.py` module (pyttsx3, gTTS, ElevenLabs)
- Adds `--tts-engine elevenlabs` option to the CLI
- Adds `--voice-id` argument for specifying the ElevenLabs voice (required when using ElevenLabs)
- Uses `eleven_turbo_v2_5` model for lowest latency — important for real-time Pi use
- Falls back to `pygame` for audio playback (preferred on Pi), then `playsound`
- Adds `elevenlabs` to `requirements.txt`
- 10 new tests covering routing, error paths, hardware ctrl lifecycle, and the API call contract

## Usage
```bash
export ELEVENLABS_API_KEY=your_key_here
python3 main.py --tts-engine elevenlabs --voice-id <your-cloned-voice-id>
```

## Test plan
- [x] `pytest -q` — 13/13 passing
- [ ] Set `ELEVENLABS_API_KEY` and a real voice ID, run with `--use-typing` to verify audio output
- [ ] Confirm `--tts-engine pyttsx3` and `--tts-engine gtts` still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)