### PR TITLE
Add local RVC+Piper TTS engine (no subscription needed)

### DIFF
--- a/main.py
+++ b/main.py
@@ -128,12 +128,19 @@ def speak_text(
     tts_enabled: bool = True,
     engine: str = "pyttsx3",
     voice_id: str = "",
+    server_url: str = "http://localhost:5050",
     hardware_ctrl=None,
 ) -> None:
     if not tts_enabled:
         print("Bot:", text)
         return
-    tts_module.speak(text, engine=engine, voice_id=voice_id, hardware_ctrl=hardware_ctrl)
+    tts_module.speak(
+        text,
+        engine=engine,
+        voice_id=voice_id,
+        server_url=server_url,
+        hardware_ctrl=hardware_ctrl,
+    )
 
 
 def main() -> None:
@@ -142,10 +149,15 @@ def main() -> None:
     parser.add_argument("--use-typing", action="store_true")
     parser.add_argument(
         "--tts-engine",
-        choices=["pyttsx3", "gtts", "elevenlabs"],
+        choices=["pyttsx3", "gtts", "elevenlabs", "local-rvc"],
         default="pyttsx3",
     )
     parser.add_argument("--voice-id", default="", help="ElevenLabs voice ID")
+    parser.add_argument(
+        "--tts-server",
+        default="http://localhost:5050",
+        help="URL of the local RVC TTS server (used with --tts-engine local-rvc)",
+    )
     parser.add_argument("--no-tts", action="store_true")
     parser.add_argument("--history-file")
     parser.add_argument("--mic-pin", type=int)
@@ -179,6 +191,7 @@ def main() -> None:
                 tts_enabled=tts_enabled,
                 engine=args.tts_engine,
                 voice_id=args.voice_id,
+                server_url=args.tts_server,
                 hardware_ctrl=hardware_ctrl,
             )
             if args.history_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ speechrecognition
 pyttsx3
 openai
 elevenlabs
+requests
 # Optional for Raspberry Pi hardware control
 # Uncomment the following line if running on a Pi
 # RPi.GPIO

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,5 @@
+# PC-side TTS server dependencies
+flask
+rvc-python
+# Piper is installed as a binary — see README for instructions
+# https://github.com/rhasspy/piper/releases

--- a/server/tts_server.py
+++ b/server/tts_server.py
@@ -1,0 +1,98 @@
+"""
+Bob skull TTS server — runs on the always-on local PC.
+Pipeline: text → Piper (base voice) → RVC (James Marsters conversion) → WAV audio
+
+Start with:
+    python server/tts_server.py \
+        --piper-model /path/to/en_US-lessac-medium.onnx \
+        --rvc-model   /path/to/james_marsters.pth \
+        --rvc-index   /path/to/james_marsters.index
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+
+from flask import Flask, Response, jsonify, request
+
+app = Flask(__name__)
+
+# Loaded once at startup — kept alive across requests to avoid model reload overhead
+_rvc_instance = None
+
+
+@app.post("/synthesize")
+def synthesize() -> tuple | Response:
+    text = (request.get_json(silent=True) or {}).get("text", "").strip()
+    if not text:
+        return jsonify(error="text is required"), 400
+
+    piper_wav = tempfile.mktemp(suffix=".wav")
+    rvc_wav = tempfile.mktemp(suffix=".wav")
+    try:
+        _piper_synthesize(text, piper_wav)
+        _rvc_convert(piper_wav, rvc_wav)
+        with open(rvc_wav, "rb") as f:
+            audio = f.read()
+        return Response(audio, mimetype="audio/wav")
+    except RuntimeError as exc:
+        return jsonify(error=str(exc)), 500
+    finally:
+        for path in (piper_wav, rvc_wav):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+def _piper_synthesize(text: str, output_path: str) -> None:
+    result = subprocess.run(
+        ["piper", "--model", app.config["PIPER_MODEL"], "--output_file", output_path],
+        input=text.encode(),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Piper failed: {result.stderr.decode().strip()}")
+
+
+def _rvc_convert(input_path: str, output_path: str) -> None:
+    if _rvc_instance is None:
+        raise RuntimeError("RVC model not loaded — was load_rvc() called at startup?")
+    _rvc_instance.infer(input_path, output_path)
+
+
+def load_rvc(model_path: str, index_path: str = "") -> None:
+    global _rvc_instance
+    try:
+        from rvc_python.infer import RVCInference
+    except ImportError:
+        raise SystemExit("[ERROR] rvc-python not installed — run: pip install rvc-python")
+    rvc = RVCInference()
+    rvc.load_model(model_path, index_path)
+    _rvc_instance = rvc
+    print(f"[INFO] RVC model loaded: {model_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bob skull local TTS server")
+    parser.add_argument("--piper-model", required=True, help="Path to Piper .onnx voice model")
+    parser.add_argument("--rvc-model", required=True, help="Path to RVC .pth model file")
+    parser.add_argument(
+        "--rvc-index", default="", help="Path to RVC .index file (optional but improves accuracy)"
+    )
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=5050)
+    args = parser.parse_args()
+
+    app.config["PIPER_MODEL"] = args.piper_model
+    load_rvc(args.rvc_model, args.rvc_index)
+
+    print(f"[INFO] TTS server listening on {args.host}:{args.port}")
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -21,7 +21,7 @@ def test_cli_options(monkeypatch, tmp_path):
         events['prompt'] = prompt
         return 'hi'
 
-    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3', voice_id='', hardware_ctrl=None):
+    def fake_speak_text(text, *, tts_enabled=True, engine='pyttsx3', voice_id='', server_url='http://localhost:5050', hardware_ctrl=None):
         events['tts_enabled'] = tts_enabled
         events['engine'] = engine
         events['hw_speak'] = hardware_ctrl is not None

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -31,6 +31,17 @@ def test_speak_routes_to_gtts(monkeypatch):
     assert called["text"] == "hello"
 
 
+def test_speak_routes_to_local_rvc(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        tts, "_speak_local_rvc",
+        lambda text, server_url="": called.update({"text": text, "url": server_url}),
+    )
+    tts.speak("hello", engine="local-rvc", server_url="http://mypc:5050")
+    assert called["text"] == "hello"
+    assert called["url"] == "http://mypc:5050"
+
+
 def test_speak_routes_to_elevenlabs(monkeypatch):
     called = {}
     monkeypatch.setattr(
@@ -89,6 +100,43 @@ def test_elevenlabs_calls_api(monkeypatch, tmp_path):
         output_format="mp3_44100_128",
     )
     assert played["bytes"] == b"chunk1chunk2"
+
+
+def test_local_rvc_missing_requests(monkeypatch, capsys):
+    monkeypatch.setattr(tts, "_optional", lambda name: None)
+    tts._speak_local_rvc("hi", server_url="http://localhost:5050")
+    assert "requests" in capsys.readouterr().out
+
+
+def test_local_rvc_server_error(monkeypatch, capsys):
+    mock_requests = mock.MagicMock()
+    mock_requests.post.side_effect = ConnectionError("refused")
+    monkeypatch.setattr(tts, "_optional", lambda name: mock_requests if name == "requests" else None)
+    tts._speak_local_rvc("hi", server_url="http://localhost:5050")
+    assert "unreachable" in capsys.readouterr().out
+
+
+def test_local_rvc_plays_wav(monkeypatch):
+    fake_audio = b"RIFF....WAVEfmt "
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.content = fake_audio
+
+    mock_requests = mock.MagicMock()
+    mock_requests.post.return_value = mock_response
+    monkeypatch.setattr(tts, "_optional", lambda name: mock_requests if name == "requests" else None)
+
+    played = {}
+    monkeypatch.setattr(tts, "_play_audio_file", lambda path: played.update({"path": path}))
+
+    tts._speak_local_rvc("You rang, Harry?", server_url="http://mypc:5050")
+
+    mock_requests.post.assert_called_once_with(
+        "http://mypc:5050/synthesize",
+        json={"text": "You rang, Harry?"},
+        timeout=30,
+    )
+    assert played["path"].endswith(".wav")
 
 
 def test_speak_hardware_ctrl_called(monkeypatch):

--- a/tests/test_tts_server.py
+++ b/tests/test_tts_server.py
@@ -1,0 +1,122 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest import mock
+import pytest
+
+import server.tts_server as srv
+
+
+@pytest.fixture(autouse=True)
+def reset_rvc():
+    """Ensure RVC singleton is cleared between tests."""
+    srv._rvc_instance = None
+    srv.app.config["PIPER_MODEL"] = "fake.onnx"
+    yield
+    srv._rvc_instance = None
+
+
+@pytest.fixture()
+def client():
+    srv.app.config["TESTING"] = True
+    with srv.app.test_client() as c:
+        yield c
+
+
+def test_synthesize_missing_text(client):
+    resp = client.post("/synthesize", json={})
+    assert resp.status_code == 400
+    assert b"text" in resp.data
+
+
+def test_synthesize_empty_text(client):
+    resp = client.post("/synthesize", json={"text": "   "})
+    assert resp.status_code == 400
+
+
+def test_synthesize_no_json(client):
+    resp = client.post("/synthesize", data="not json", content_type="text/plain")
+    assert resp.status_code == 400
+
+
+def test_synthesize_piper_failure(client):
+    mock_rvc = mock.MagicMock()
+    srv._rvc_instance = mock_rvc
+
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=1, stderr=b"model not found")
+        resp = client.post("/synthesize", json={"text": "hello Bob"})
+
+    assert resp.status_code == 500
+    assert b"Piper" in resp.data
+
+
+def test_synthesize_rvc_not_loaded(client):
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=0)
+        resp = client.post("/synthesize", json={"text": "hello"})
+    assert resp.status_code == 500
+    assert b"RVC" in resp.data
+
+
+def test_synthesize_happy_path(client, tmp_path):
+    fake_wav = b"RIFF....WAVEfmt "
+    mock_rvc = mock.MagicMock()
+
+    def fake_infer(input_path, output_path):
+        with open(output_path, "wb") as f:
+            f.write(fake_wav)
+
+    mock_rvc.infer.side_effect = fake_infer
+    srv._rvc_instance = mock_rvc
+
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=0)
+        resp = client.post("/synthesize", json={"text": "You rang, Harry?"})
+
+    assert resp.status_code == 200
+    assert resp.mimetype == "audio/wav"
+    assert resp.data == fake_wav
+    mock_rvc.infer.assert_called_once()
+
+
+def test_piper_command_uses_configured_model(client):
+    mock_rvc = mock.MagicMock()
+    srv._rvc_instance = mock_rvc
+    srv.app.config["PIPER_MODEL"] = "/models/en_US-lessac-medium.onnx"
+
+    def fake_infer(inp, out):
+        with open(out, "wb") as f:
+            f.write(b"audio")
+
+    mock_rvc.infer.side_effect = fake_infer
+
+    with mock.patch("subprocess.run") as mock_run:
+        mock_run.return_value = mock.Mock(returncode=0)
+        client.post("/synthesize", json={"text": "test"})
+
+    cmd = mock_run.call_args[0][0]
+    assert "/models/en_US-lessac-medium.onnx" in cmd
+    assert "piper" in cmd
+
+
+def test_load_rvc_missing_package():
+    with mock.patch.dict("sys.modules", {"rvc_python": None, "rvc_python.infer": None}):
+        with pytest.raises(SystemExit, match="rvc-python"):
+            srv.load_rvc("model.pth")
+
+
+def test_load_rvc_success():
+    mock_rvc_cls = mock.MagicMock()
+    mock_instance = mock.MagicMock()
+    mock_rvc_cls.return_value = mock_instance
+
+    mock_module = mock.MagicMock()
+    mock_module.RVCInference = mock_rvc_cls
+
+    with mock.patch.dict("sys.modules", {"rvc_python": mock_module, "rvc_python.infer": mock_module}):
+        srv.load_rvc("model.pth", "model.index")
+
+    mock_instance.load_model.assert_called_once_with("model.pth", "model.index")
+    assert srv._rvc_instance is mock_instance

--- a/tts.py
+++ b/tts.py
@@ -20,6 +20,7 @@ def speak(
     *,
     engine: str = "pyttsx3",
     voice_id: str = "",
+    server_url: str = "http://localhost:5050",
     hardware_ctrl=None,
 ) -> None:
     print("Bot:", text)
@@ -29,6 +30,8 @@ def speak(
     try:
         if engine == "elevenlabs":
             _speak_elevenlabs(text, voice_id=voice_id)
+        elif engine == "local-rvc":
+            _speak_local_rvc(text, server_url=server_url)
         elif engine == "gtts":
             _speak_gtts(text)
         else:
@@ -90,6 +93,29 @@ def _speak_elevenlabs(text: str, *, voice_id: str = "") -> None:
 
     with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as fp:
         fp.write(audio_bytes)
+        fname = fp.name
+
+    try:
+        _play_audio_file(fname)
+    finally:
+        os.remove(fname)
+
+
+def _speak_local_rvc(text: str, *, server_url: str = "http://localhost:5050") -> None:
+    requests = _optional("requests")
+    if requests is None:
+        print("[WARN] requests package not installed — run: pip install requests")
+        return
+
+    try:
+        resp = requests.post(f"{server_url}/synthesize", json={"text": text}, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        print(f"[ERROR] TTS server unreachable at {server_url}: {exc}")
+        return
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as fp:
+        fp.write(resp.content)
         fname = fp.name
 
     try:


### PR DESCRIPTION
## Summary
- Adds a split architecture so the skull runs entirely offline — no ElevenLabs subscription required
- **PC side** (`server/tts_server.py`): Flask HTTP server runs Piper → RVC pipeline, loads the James Marsters voice model once at startup, stays alive between calls
- **Pi side** (`tts.py`): new `--tts-engine local-rvc` option sends text to the server over LAN, plays back the returned WAV
- `--tts-server` arg sets the server URL (default `http://localhost:5050`)

## Architecture
```
[Pi] mic → STT → OpenAI → speak_text()
                              ↓
                    POST /synthesize {text}
                              ↓
                    [always-on PC]
                    Piper (base voice WAV)
                              ↓
                    RVC (James Marsters conversion)
                              ↓
                    WAV audio → Pi plays it
```

## PC setup (one-time)
```bash
# 1. Install server deps
pip install -r server/requirements.txt

# 2. Install Piper binary — https://github.com/rhasspy/piper/releases
#    Download en_US-lessac-medium.onnx (or any English base voice)

# 3. Train or download a James Marsters RVC model (.pth + .index)
#    Community models at: https://applio.org/models

# 4. Start the server
python server/tts_server.py \
    --piper-model /path/to/en_US-lessac-medium.onnx \
    --rvc-model   /path/to/james_marsters.pth \
    --rvc-index   /path/to/james_marsters.index
```

## Pi usage
```bash
python3 main.py --tts-engine local-rvc --tts-server http://<pc-ip>:5050
```

## Test plan
- [x] `pytest -q` — 26/26 passing
- [ ] Run server with real Piper model, hit `/synthesize` with curl to verify WAV response
- [ ] Connect Pi, confirm end-to-end audio playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)